### PR TITLE
Redesign CLI landing page for clearer messaging and flow

### DIFF
--- a/app/cli/page.tsx
+++ b/app/cli/page.tsx
@@ -1,860 +1,239 @@
 "use client";
 
 import SiteNav from "@/components/site-nav";
-import { ArrowRight, Terminal, Zap, Lock, BarChart3, Code2, Download, Copy, Check } from "lucide-react";
+import {
+  ArrowRight,
+  Check,
+  Copy,
+  Download,
+  Github,
+  Lock,
+  Repeat2,
+  ShieldCheck,
+  Terminal,
+  Timer,
+  Zap,
+} from "lucide-react";
 import { useState } from "react";
 
-const CSS = `
-  @import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;1,400;1,500&family=JetBrains+Mono:wght@400;500;700&family=Instrument+Serif:ital@0;1&display=swap');
+const installCommand = "npx @hookflo/tern-dev --port 3000";
 
-  :root {
-    --paper:   #f7f4ef;
-    --paper2:  #f0ebe2;
-    --ink:     #1a1714;
-    --ink2:    #3d3830;
-    --ink3:    #6b6358;
-    --ink4:    #9e9488;
-    --border:  #d8d0c4;
-    --border2: #c4baad;
-    --accent:  #2c5f8a;
-    --mono: 'JetBrains Mono', monospace;
-    --serif: 'Lora', Georgia, serif;
-    --display: 'Instrument Serif', Georgia, serif;
-  }
+const features = [
+  {
+    icon: Zap,
+    title: "Instant tunnel URL",
+    description: "Start in seconds and receive webhooks at a public HTTPS endpoint mapped to localhost.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Signature verification",
+    description: "Validate webhook signatures for Stripe, GitHub, Clerk, and custom integrations.",
+  },
+  {
+    icon: Repeat2,
+    title: "Replay and debug",
+    description: "Resend failed events and iterate quickly without waiting for providers to retry.",
+  },
+  {
+    icon: Lock,
+    title: "Zero persistence",
+    description: "Events stay in memory during your session and disappear when you stop the CLI.",
+  },
+];
 
-  .tern-root { font-family: var(--serif); background: var(--paper); color: var(--ink); }
-  .tern-root * { box-sizing: border-box; }
-
-  /* HERO */
-  .cli-hero {
-    padding: 60px clamp(20px,5vw,80px) 80px;
-    max-width: 1200px; margin: 0 auto;
-    text-align: center;
-    position: relative;
-    background: linear-gradient(135deg, 
-      #f7f4ef 0%,
-      #fde4d0 12%,
-      #f9cfc8 22%,
-      #f2b5d4 35%,
-      #e89fd8 50%,
-      #d89fdb 62%,
-      #c8addd 72%,
-      #b8c5e0 85%,
-      #a8d8e8 100%);
-    background-attachment: fixed;
-    overflow: hidden;
-    min-height: auto;
-  }
-  
-  .cli-hero::before {
-    content: '';
-    position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
-    background-image: 
-      url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='2.5' numOctaves='4' seed='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0.3'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23noiseFilter)' opacity='1'/%3E%3C/svg%3E");
-    background-size: 200px 200px;
-    opacity: 0.35;
-    pointer-events: none;
-    mix-blend-mode: overlay;
-  }
-  
-  .cli-hero::after {
-    content: '';
-    position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
-    background-image: 
-      radial-gradient(circle at 10% 20%, rgba(0,0,0,0.04) 0%, transparent 40%),
-      radial-gradient(circle at 90% 30%, rgba(0,0,0,0.05) 0%, transparent 35%),
-      radial-gradient(circle at 15% 85%, rgba(0,0,0,0.03) 0%, transparent 45%),
-      radial-gradient(circle at 85% 80%, rgba(0,0,0,0.04) 0%, transparent 40%),
-      radial-gradient(ellipse 1000px 300px at 50% 0%, rgba(255,255,255,0.05) 0%, transparent 100%);
-    pointer-events: none;
-    mix-blend-mode: multiply;
-  }
-  
-  .cli-hero-lines {
-    position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
-    opacity: 0.08;
-    pointer-events: none;
-  }
-  
-  .cli-hero-lines svg {
-    width: 100%; height: 100%;
-  }
-  
-  .cli-hero > * {
-    position: relative;
-    z-index: 1;
-  }
-  .cli-eyebrow {
-    display: inline-flex; align-items: center; gap: 8px;
-    font-family: var(--mono); font-size: 10px; font-weight: 700;
-    letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink3); margin-bottom: 32px;
-  }
-  .cli-eyebrow::before { content: ''; display: block; width: 24px; height: 1px; background: var(--ink3); }
-  
-  .cli-h1 {
-    font-family: var(--display); font-size: clamp(36px,5.5vw,64px);
-    font-weight: 400; line-height: 1.15; letter-spacing: -0.02em;
-    color: var(--ink); margin: 0 auto 16px; max-width: 850px;
-  }
-  .cli-h1 em { font-style: italic; color: var(--accent); }
-  
-  .cli-subtitle {
-    font-size: 16px; color: var(--ink2);
-    margin: 0 auto 32px; max-width: 680px; line-height: 1.6;
-  }
-
-  .cli-actions {
-    display: flex; align-items: center; justify-content: center;
-    gap: 20px; flex-wrap: wrap; margin-bottom: 60px;
-  }
-  .cli-btn-primary {
-    font-family: var(--mono); font-size: 12px; font-weight: 700;
-    letter-spacing: 0.08em; text-transform: uppercase;
-    color: var(--paper); background: var(--ink); border: none;
-    padding: 14px 36px; border-radius: 8px; cursor: pointer;
-    text-decoration: none; transition: all .3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    display: inline-flex; align-items: center; gap: 10px;
-    box-shadow: 0 4px 12px rgba(26,23,20,.15);
-  }
-  .cli-btn-primary:hover { 
-    transform: translateY(-4px);
-    box-shadow: 0 12px 32px rgba(26,23,20,.25);
-    background: #2a2520;
-  }
-  
-  .cli-btn-secondary {
-    font-family: var(--mono); font-size: 12px; font-weight: 700;
-    letter-spacing: 0.08em; text-transform: uppercase;
-    color: var(--ink); background: white; border: 1.5px solid var(--border);
-    padding: 12px 36px; border-radius: 8px; cursor: pointer;
-    text-decoration: none; transition: all .3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    display: inline-flex; align-items: center; gap: 10px;
-    box-shadow: 0 2px 8px rgba(26,23,20,.06);
-  }
-  .cli-btn-secondary:hover { 
-    border-color: var(--accent);
-    color: var(--accent);
-    transform: translateY(-4px);
-    box-shadow: 0 8px 24px rgba(44,95,138,.12);
-  }
-
-  .cli-install {
-    background: linear-gradient(135deg, #0f0e0c 0%, #1a1714 100%);
-    border: 1px solid rgba(255,255,255,.08);
-    border-radius: 12px; padding: 18px 28px;
-    font-family: var(--mono); font-size: 14px; font-weight: 500;
-    color: #e8e8e0; display: inline-flex;
-    align-items: center; gap: 16px; max-width: 580px;
-    margin: 0 auto; 
-    box-shadow: 0 12px 32px rgba(0,0,0,.25);
-  }
-  .cli-install span { 
-    color: #6dbfe5;
-    font-weight: 600;
-  }
-  .cli-copy-btn {
-    background: rgba(44,95,138,0.2);
-    border: 1px solid rgba(44,95,138,0.4);
-    cursor: pointer;
-    color: #6dbfe5; 
-    padding: 8px 14px;
-    border-radius: 6px;
-    display: flex; 
-    align-items: center;
-    gap: 6px;
-    transition: all .3s;
-    font-family: var(--mono);
-    font-size: 11px;
-    font-weight: 600;
-    margin-left: auto;
-  }
-  .cli-copy-btn:hover { 
-    background: rgba(44,95,138,0.3);
-    border-color: rgba(44,95,138,0.6);
-    box-shadow: 0 0 12px rgba(109,191,229,.2);
-  }
-
-  /* FEATURE SECTION */
-  .cli-features {
-    padding: clamp(60px,8vw,100px) clamp(20px,5vw,80px);
-    background: white; border-top: 1px solid var(--border);
-  }
-  .cli-features-inner { max-width: 1400px; margin: 0 auto; }
-  
-  .cli-section-label {
-    font-family: var(--mono); font-size: 10px; font-weight: 700;
-    letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink4);
-    margin-bottom: 20px; display: flex; align-items: center; gap: 10px;
-  }
-  .cli-section-label::after { 
-    content: ''; flex: 1; height: 1px; background: var(--border);
-    max-width: 60px;
-  }
-  
-  .cli-h2 {
-    font-family: var(--display); font-size: clamp(32px,5vw,48px);
-    font-weight: 400; line-height: 1.15; color: var(--ink);
-    margin-bottom: 20px;
-  }
-  .cli-h2 em { font-style: italic; }
-  
-  .cli-section-desc {
-    font-size: 16px; color: var(--ink3); max-width: 600px;
-    line-height: 1.65; margin-bottom: 56px;
-  }
-
-  .cli-features-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 24px; margin-bottom: 60px;
-  }
-  .cli-feature-card {
-    background: white;
-    border: 1px solid var(--border);
-    border-radius: 16px; padding: 40px 32px;
-    transition: all .3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    position: relative;
-    overflow: visible;
-  }
-  
-  .cli-feature-card::before {
-    content: '';
-    position: absolute;
-    top: -12px; right: -12px;
-    width: 80px; height: 80px;
-    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10 15 Q35 5, 60 20' stroke='%232c5f8a' stroke-width='2' fill='none' opacity='0.15' stroke-linecap='round'/%3E%3Cpath d='M5 50 L65 40' stroke='%232c5f8a' stroke-width='1.5' fill='none' opacity='0.1' stroke-linecap='round'/%3E%3Cpath d='M20 70 Q40 65, 70 75' stroke='%23e89fd8' stroke-width='1.5' fill='none' opacity='0.12' stroke-linecap='round'/%3E%3C/svg%3E");
-    background-size: 100%;
-    background-repeat: no-repeat;
-    pointer-events: none;
-    z-index: 0;
-  }
-  
-  .cli-feature-card::after {
-    content: '';
-    position: absolute;
-    bottom: -8px; left: -16px;
-    width: 100px; height: 100px;
-    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 20 Q25 10, 50 25' stroke='%23d89fdb' stroke-width='1.5' fill='none' opacity='0.12' stroke-linecap='round'/%3E%3Cpath d='M70 0 L85 60' stroke='%232c5f8a' stroke-width='1' fill='none' opacity='0.08' stroke-linecap='round'/%3E%3C/svg%3E");
-    background-size: 100%;
-    background-repeat: no-repeat;
-    pointer-events: none;
-    z-index: 0;
-  }
-  
-  .cli-feature-card:hover {
-    transform: translateY(-8px);
-    box-shadow: 0 20px 48px rgba(26,23,20,.14), 0 2px 8px rgba(26,23,20,.06);
-    border-color: var(--accent);
-  }
-  
-  .cli-feature-icon {
-    width: 56px; height: 56px;
-    display: flex; align-items: center; justify-content: center;
-    background: linear-gradient(135deg, rgba(44,95,138,0.1) 0%, rgba(44,95,138,0.05) 100%);
-    border: 1.5px solid rgba(44,95,138,0.25);
-    border-radius: 12px; margin-bottom: 24px;
-    color: var(--accent);
-    font-weight: 600;
-    position: relative;
-    z-index: 10;
-    transition: all .3s ease;
-  }
-  
-  .cli-feature-card:hover .cli-feature-icon {
-    background: linear-gradient(135deg, rgba(44,95,138,0.15) 0%, rgba(44,95,138,0.08) 100%);
-    border-color: var(--accent);
-  }
-  
-  .cli-feature-title {
-    font-family: var(--display); font-size: 20px; font-weight: 400;
-    color: var(--ink); margin-bottom: 12px;
-    position: relative;
-    z-index: 10;
-  }
-  
-  .cli-feature-desc {
-    font-size: 15px; color: var(--ink3); line-height: 1.65;
-    position: relative;
-    z-index: 10;
-  }
-
-  /* DASHBOARD SECTION */
-  .cli-dashboard-section {
-    padding: clamp(60px,8vw,100px) clamp(20px,5vw,80px);
-    background: var(--paper); border-top: 1px solid var(--border);
-  }
-  .cli-dashboard-inner { max-width: 1400px; margin: 0 auto; }
-  
-  .cli-dashboard-grid {
-    display: grid; grid-template-columns: 1fr 1fr;
-    gap: 60px; align-items: center;
-    margin-bottom: 40px;
-  }
-  @media(max-width:1000px) {
-    .cli-dashboard-grid { grid-template-columns: 1fr; gap: 40px; }
-  }
-
-  .cli-dashboard-content h3 {
-    font-family: var(--display); font-size: clamp(28px,4vw,40px);
-    font-weight: 400; line-height: 1.2; color: var(--ink); margin-bottom: 20px;
-  }
-  .cli-dashboard-content p {
-    font-size: 15px; color: var(--ink3); line-height: 1.7; margin-bottom: 24px;
-  }
-  .cli-dashboard-list {
-    list-style: none; padding: 0; margin: 0;
-    display: flex; flex-direction: column; gap: 14px;
-  }
-  .cli-dashboard-list li {
-    font-size: 14px; color: var(--ink2); display: flex; align-items: flex-start; gap: 12px;
-  }
-  .cli-dashboard-list li::before {
-    content: '✓'; color: var(--accent); font-weight: bold;
-    flex-shrink: 0; margin-top: 2px;
-  }
-
-  .cli-dashboard-visual {
-    background: linear-gradient(135deg, #fdfbf8 0%, white 100%);
-    border: 1px solid var(--border);
-    border-radius: 16px; 
-    padding: 28px;
-    font-family: var(--mono); font-size: 13px;
-    color: var(--ink2); line-height: 1.8;
-    position: relative;
-    overflow: hidden;
-    box-shadow: 0 4px 12px rgba(26,23,20,.04);
-  }
-  
-  .cli-dashboard-visual::before {
-    content: '';
-    position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
-    background-image: 
-      url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='dashNoise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='3' numOctaves='3' seed='4' /%3E%3C/filter%3E%3Crect width='100' height='100' filter='url(%23dashNoise)' opacity='1'/%3E%3C/svg%3E");
-    background-size: 100px 100px;
-    opacity: 0.1;
-    pointer-events: none;
-    mix-blend-mode: overlay;
-  }
-  
-  .cli-dashboard-visual .line {
-    margin-bottom: 10px; display: flex; align-items: center; gap: 8px;
-    position: relative;
-    z-index: 1;
-  }
-  
-  .cli-dashboard-visual .key { color: var(--accent); font-weight: 600; }
-  .cli-dashboard-visual .val { color: var(--ink3); }
-
-  /* SPEED SECTION */
-  .cli-speed-section {
-    padding: clamp(60px,8vw,100px) clamp(20px,5vw,80px);
-    background: white; border-top: 1px solid var(--border);
-  }
-  .cli-speed-inner { max-width: 1400px; margin: 0 auto; }
-
-  .cli-stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 16px; 
-  }
-  
-  .cli-stat-card {
-    background: linear-gradient(135deg, #fdfbf8 0%, white 100%);
-    border: 1px solid var(--border);
-    border-radius: 16px;
-    padding: 36px 28px;
-    text-align: center;
-    position: relative;
-    overflow: hidden;
-    transition: all .3s cubic-bezier(0.34, 1.56, 0.64, 1);
-  }
-  
-  .cli-stat-card::before {
-    content: '';
-    position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
-    background-image: 
-      url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='statNoise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='3' numOctaves='3' seed='3' /%3E%3C/filter%3E%3Crect width='100' height='100' filter='url(%23statNoise)' opacity='1'/%3E%3C/svg%3E");
-    background-size: 100px 100px;
-    opacity: 0.12;
-    pointer-events: none;
-    mix-blend-mode: overlay;
-  }
-  
-  .cli-stat-card:hover {
-    transform: translateY(-6px);
-    border-color: var(--accent);
-    box-shadow: 0 16px 40px rgba(44,95,138,0.1);
-  }
-  
-  .cli-stat-value {
-    font-family: var(--display); font-size: 48px; font-style: italic;
-    font-weight: 600; color: var(--accent); line-height: 1;
-    margin-bottom: 12px;
-    position: relative;
-    z-index: 2;
-  }
-  
-  .cli-stat-label {
-    font-family: var(--mono); font-size: 10px; font-weight: 700;
-    letter-spacing: 0.12em; text-transform: uppercase;
-    color: var(--ink3);
-    position: relative;
-    z-index: 2;
-  }
-
-  /* CTA SECTION */
-  .cli-cta {
-    padding: clamp(60px,8vw,100px) clamp(20px,5vw,80px);
-    background: var(--ink);
-  }
-  .cli-cta-inner { max-width: 900px; margin: 0 auto; text-align: center; }
-  
-  .cli-cta-h {
-    font-family: var(--display); font-size: clamp(32px,5vw,48px);
-    font-weight: 400; color: var(--paper); margin-bottom: 20px;
-  }
-  .cli-cta-desc {
-    font-size: 16px; color: rgba(247,244,239,.6);
-    line-height: 1.7; margin-bottom: 36px;
-  }
-  .cli-cta-btn {
-    font-family: var(--mono); font-size: 13px; font-weight: 700;
-    letter-spacing: 0.08em; text-transform: uppercase;
-    color: var(--ink); background: var(--paper); border: none;
-    padding: 14px 32px; border-radius: 6px; cursor: pointer;
-    text-decoration: none; transition: all .2s;
-    display: inline-flex; align-items: center; gap: 8px;
-  }
-  .cli-cta-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(0,0,0,.2);
-  }
-
-  /* CODE BLOCK */
-  .cli-code-block {
-    background: #0f0e0c; border: 1px solid rgba(255,255,255,.08);
-    border-radius: 12px; overflow: hidden;
-    font-family: var(--mono); color: #e8e8e0;
-    font-size: 13px; line-height: 1.8;
-    margin: 40px 0;
-    box-shadow: 0 20px 60px rgba(0,0,0,.3);
-  }
-  .cli-code-header {
-    background: #1a1714; padding: 14px 20px;
-    border-bottom: 1px solid rgba(255,255,255,.05);
-    display: flex; align-items: center; gap: 12px;
-    font-size: 11px; color: rgba(255,255,255,.35);
-    letter-spacing: 0.05em;
-    font-weight: 500;
-  }
-  .cli-code-dots {
-    display: flex; gap: 8px;
-  }
-  .cli-code-dot {
-    width: 12px; height: 12px; border-radius: 50%;
-    background: #444;
-  }
-  .cli-code-dot:nth-child(1) { background: #ff6058; }
-  .cli-code-dot:nth-child(2) { background: #ffbd2e; }
-  .cli-code-dot:nth-child(3) { background: #27c93f; }
-  .cli-code-body {
-    padding: 24px 28px; overflow-x: auto; white-space: pre;
-  }
-  .cli-code-body .str { color: #a6d155; }
-  .cli-code-body .num { color: #d4a574; }
-  .cli-code-body .key { color: #6dbfe5; }
-  .cli-code-body .bool { color: #d9829b; }
-
-  /* ANIMATIONS */
-  @keyframes fadeUp {
-    from { opacity: 0; transform: translateY(20px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-  .fade-in { animation: fadeUp .6s ease both; }
-  
-  @keyframes typing {
-    0% { width: 0; }
-    100% { width: 100%; }
-  }
-  @keyframes blink {
-    0%, 49% { opacity: 1; }
-    50%, 100% { opacity: 0; }
-  }
-  
-  .cli-code-terminal {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 4px;
-    font-weight: 500;
-  }
-  
-  .cli-code-text {
-    overflow: hidden;
-    white-space: nowrap;
-    display: inline-block;
-    animation: typing 2.5s steps(50, end) infinite;
-  }
-  
-  .cli-code-cursor {
-    display: inline-block;
-    width: 2px;
-    height: 1em;
-    background: #6dbfe5;
-    animation: blink 1s infinite;
-  }
-`;
+const quickSteps = [
+  "Run tern and forward to your local app on port 3000.",
+  "Copy the generated tunnel URL into your webhook provider.",
+  "Open the local dashboard and inspect each request in real time.",
+];
 
 export default function CLIPage() {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText("npx @hookflo/tern-dev --port 3000");
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(installCommand);
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    setTimeout(() => setCopied(false), 1800);
   };
 
   return (
-    <div className="tern-root">
-      <style>{CSS}</style>
+    <div className="min-h-screen bg-stone-50 text-stone-900">
       <SiteNav />
 
-      {/* HERO */}
-      <section className="cli-hero">
-        <div className="cli-hero-lines">
-          <svg viewBox="0 0 1200 600" preserveAspectRatio="xMidYMid slice">
-            <defs>
-              <linearGradient id="lineGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stopColor="rgba(44,95,138,0.3)" />
-                <stop offset="100%" stopColor="rgba(232,159,216,0.2)" />
-              </linearGradient>
-            </defs>
-            {/* Left diagonal accent lines */}
-            <path d="M 0 200 Q 200 150, 300 180" stroke="url(#lineGrad)" strokeWidth="1" fill="none" vectorEffect="non-scaling-stroke" />
-            <path d="M 0 300 Q 250 250, 400 320" stroke="url(#lineGrad)" strokeWidth="0.8" fill="none" vectorEffect="non-scaling-stroke" opacity="0.6" />
-            
-            {/* Right diagonal accent lines */}
-            <path d="M 1200 150 Q 950 200, 800 180" stroke="url(#lineGrad)" strokeWidth="1" fill="none" vectorEffect="non-scaling-stroke" />
-            <path d="M 1200 400 Q 900 350, 700 380" stroke="url(#lineGrad)" strokeWidth="0.8" fill="none" vectorEffect="non-scaling-stroke" opacity="0.6" />
-            
-            {/* Subtle grid hints */}
-            <line x1="0" y1="600" x2="600" y2="300" stroke="url(#lineGrad)" strokeWidth="0.5" opacity="0.3" vectorEffect="non-scaling-stroke" />
-            <line x1="1200" y1="600" x2="600" y2="300" stroke="url(#lineGrad)" strokeWidth="0.5" opacity="0.3" vectorEffect="non-scaling-stroke" />
-          </svg>
-        </div>
-        <div className="cli-eyebrow">Local Webhook Tunnel</div>
-        <h1 className="cli-h1">
-          Secure webhooks, <em>zero storage</em>
-        </h1>
-        <p className="cli-subtitle">
-          Test webhooks locally without ngrok or third-party services. One command. Public URL. Zero persistence.
-        </p>
-        
-        <div className="cli-actions">
-          <a href="https://github.com/Hookflo/tern-dev" className="cli-btn-primary" target="_blank" rel="noreferrer">
-            <Terminal size={16} />
-            GitHub Repository
-          </a>
-          <a href="https://www.npmjs.com/package/@hookflo/tern-dev" className="cli-btn-secondary" target="_blank" rel="noreferrer">
-            <Download size={16} />
-            View on NPM
-          </a>
-        </div>
-
-        <div className="cli-install">
-          <span>$</span>
-          <code>npx @hookflo/tern-dev --port 3000</code>
-          <button className="cli-copy-btn" onClick={handleCopy} title="Copy command">
-            {copied ? <Check size={16} /> : <Copy size={16} />}
-          </button>
-        </div>
-      </section>
-
-      {/* FEATURES */}
-      <section className="cli-features">
-        <div className="cli-features-inner">
-          <div className="cli-section-label">Core Capabilities</div>
-          <h2 className="cli-h2">Everything you need for webhook development</h2>
-          <p className="cli-section-desc">
-            A complete toolkit for testing webhooks locally with live event inspection, signature verification, and replay controls.
-          </p>
-
-          <div className="cli-features-grid">
-            <div className="cli-feature-card fade-in">
-              <div className="cli-feature-icon">
-                <Zap size={24} />
-              </div>
-              <h3 className="cli-feature-title">Instant Tunnel</h3>
-              <p className="cli-feature-desc">Get a public HTTPS URL in seconds. Route webhooks to your local development server.</p>
-            </div>
-
-            <div className="cli-feature-card fade-in" style={{animationDelay: '.1s'}}>
-              <div className="cli-feature-icon">
-                <BarChart3 size={24} />
-              </div>
-              <h3 className="cli-feature-title">Live Dashboard</h3>
-              <p className="cli-feature-desc">Real-time event log with full payload inspection, headers, responses, and side-by-side diffs.</p>
-            </div>
-
-            <div className="cli-feature-card fade-in" style={{animationDelay: '.2s'}}>
-              <div className="cli-feature-icon">
-                <Lock size={24} />
-              </div>
-              <h3 className="cli-feature-title">Zero Storage</h3>
-              <p className="cli-feature-desc">Everything lives in RAM. No data persists. Exit with Ctrl+C and it's gone instantly.</p>
-            </div>
-
-            <div className="cli-feature-card fade-in" style={{animationDelay: '.3s'}}>
-              <div className="cli-feature-icon">
-                <Code2 size={24} />
-              </div>
-              <h3 className="cli-feature-title">Signature Verification</h3>
-              <p className="cli-feature-desc">Built-in signature verification guidance for Stripe, GitHub, Clerk, and custom webhooks.</p>
-            </div>
-
-            <div className="cli-feature-card fade-in" style={{animationDelay: '.4s'}}>
-              <div className="cli-feature-icon">
-                <ArrowRight size={24} />
-              </div>
-              <h3 className="cli-feature-title">Replay Events</h3>
-              <p className="cli-feature-desc">Resend webhooks with one click. Test error handling and edge cases easily.</p>
-            </div>
-
-            <div className="cli-feature-card fade-in" style={{animationDelay: '.5s'}}>
-              <div className="cli-feature-icon">
-                <Terminal size={24} />
-              </div>
-              <h3 className="cli-feature-title">Config File Support</h3>
-              <p className="cli-feature-desc">Persistent configuration with tern.config.json. Rate limiting, IP blocking, and more.</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* DASHBOARD */}
-      <section className="cli-dashboard-section">
-        <div className="cli-dashboard-inner">
-          <div className="cli-section-label">Dashboard Features</div>
-          <h2 className="cli-h2">Powerful inspection and debugging</h2>
-
-          <div className="cli-dashboard-grid">
-            <div className="cli-dashboard-content">
-              <h3>Everything at a glance</h3>
-              <p>The local dashboard shows every webhook in real-time with complete visibility into payloads, headers, and responses.</p>
-              <ul className="cli-dashboard-list">
-                <li>Payload inspection with JSON formatting</li>
-                <li>Full HTTP headers with signature validation</li>
-                <li>Response status and latency metrics</li>
-                <li>Event comparison with side-by-side diffs</li>
-                <li>Failed events in Dead Letter Queue</li>
-                <li>One-click replay and export as cURL/fetch</li>
-              </ul>
-            </div>
-            
-            <div className="cli-dashboard-visual">
-              <div className="line">
-                <span className="key">tunnel</span>
-                <span className="val">→ https://abc123.relay.tern.hookflo.com</span>
-              </div>
-              <div className="line">
-                <span className="key">dashboard</span>
-                <span className="val">→ http://localhost:2019</span>
-              </div>
-              <div className="line">
-                <span className="key">forwarding</span>
-                <span className="val">→ localhost:3000</span>
-              </div>
-              <div style={{marginTop: 16, borderTop: '1px solid var(--border)', paddingTop: 16, color: '#059669'}}>
-                ✓ Ctrl+C to end session
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* SPEED & STATS */}
-      <section className="cli-speed-section">
-        <div className="cli-speed-inner">
-          <div className="cli-section-label">Performance</div>
-          <h2 className="cli-h2">Built for speed and reliability</h2>
-
-          <div className="cli-stats-grid">
-            <div className="cli-stat-card">
-              <div className="cli-stat-value">{`<100ms`}</div>
-              <div className="cli-stat-label">Tunnel Latency</div>
-            </div>
-            <div className="cli-stat-card">
-              <div className="cli-stat-value">∞</div>
-              <div className="cli-stat-label">Requests Per Session</div>
-            </div>
-            <div className="cli-stat-card">
-              <div className="cli-stat-value">500</div>
-              <div className="cli-stat-label">Event Buffer Size</div>
-            </div>
-            <div className="cli-stat-card">
-              <div className="cli-stat-value">0B</div>
-              <div className="cli-stat-label">Data Persisted</div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* QUICKSTART */}
-      <section className="cli-features">
-        <div className="cli-features-inner">
-          <div className="cli-section-label">Getting Started</div>
-          <h2 className="cli-h2">Three steps to webhook testing</h2>
-
-          <div className="cli-code-block">
-            <div className="cli-code-header">
-              <div className="cli-code-dots">
-                <div className="cli-code-dot" style={{background: '#ff5f57'}} />
-                <div className="cli-code-dot" style={{background: '#febc2e'}} />
-                <div className="cli-code-dot" style={{background: '#28c940'}} />
-              </div>
-              <span>$ terminal</span>
-            </div>
-            <div className="cli-code-body">{`# 1. Start the tunnel
-$ npx @hookflo/tern-dev --port 3000
-
-  ████████╗███████╗██████╗ ███╗  ██╗
-     ██║   ██╔════╝██╔══██╗████╗ ██║
-     ██║   █████╗  ██████╔╝██╔██╗██║
-     ██║   ██╔══╝  ██╔══██╗██║╚████║
-     ██║   ███████╗██║  ██║██║ ╚███║
-     ╚═╝   ╚══════╝╚═╝  ╚═╝╚═╝  ╚══╝
-
-  tunnel    →  https://abc123.relay.tern.hookflo.com
-  dashboard →  http://localhost:2019
-  forwarding →  localhost:3000
-
-# 2. Copy tunnel URL to your webhook provider
-# 3. Open dashboard and watch events flow in real-time`}</div>
-          </div>
-        </div>
-      </section>
-
-      {/* LIVE DASHBOARD */}
-      <section className="cli-dashboard-section" style={{background: 'linear-gradient(180deg, #f0ebe2 0%, #f7f4ef 100%)'}}>
-        <div className="cli-dashboard-inner">
-          <div className="cli-section-label">Live Dashboard</div>
-          <h2 className="cli-h2">Real-time webhook debugging</h2>
-          <p className="cli-section-desc">Watch every webhook in real-time with full payload inspection, headers, responses, and detailed metrics. The local dashboard at http://localhost:2019 gives you instant visibility.</p>
-
-          <div style={{marginTop: 48, borderRadius: '16px', overflow: 'hidden', border: '1px solid var(--border)', boxShadow: '0 12px 40px rgba(26,23,20,.12)'}}>
-            <img src="/tern-dashboard.jpg" alt="Tern CLI Live Dashboard showing real-time webhook events with payload inspection" style={{width: '100%', height: 'auto', display: 'block'}} />
-          </div>
-
-          <div style={{marginTop: 40, background: 'white', border: '1px solid var(--border)', borderRadius: '16px', padding: '32px', boxShadow: '0 4px 12px rgba(26,23,20,.08)'}}>
-            <div style={{fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink4)', marginBottom: 24, letterSpacing: '0.05em', fontWeight: 600}}>LIVE EVENTS LOG SAMPLE • 3 webhooks received</div>
-            
-            <div style={{marginBottom: 16, paddingBottom: 16, borderBottom: '1px solid var(--border)'}}>
-              <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8}}>
-                <span style={{fontFamily: 'var(--mono)', fontSize: '12px', color: 'var(--ink)', fontWeight: 600}}>POST /stripe/webhook</span>
-                <span style={{background: '#dcfce7', color: '#166534', padding: '4px 10px', borderRadius: '4px', fontFamily: 'var(--mono)', fontSize: '10px', fontWeight: 700}}>200 OK</span>
-              </div>
-              <div style={{display: 'flex', gap: '16px', fontSize: '12px', color: 'var(--ink3)'}}>
-                <span>event_id: <code style={{color: 'var(--accent)', fontFamily: 'var(--mono)'}}>evt_123abc</code></span>
-                <span>type: <code style={{color: 'var(--accent)', fontFamily: 'var(--mono)'}}>charge.succeeded</code></span>
-                <span style={{marginLeft: 'auto'}}>2.4ms</span>
-              </div>
-            </div>
-
-            <div style={{marginBottom: 16, paddingBottom: 16, borderBottom: '1px solid var(--border)'}}>
-              <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8}}>
-                <span style={{fontFamily: 'var(--mono)', fontSize: '12px', color: 'var(--ink)', fontWeight: 600}}>POST /github/events</span>
-                <span style={{background: '#fecaca', color: '#7f1d1d', padding: '4px 10px', borderRadius: '4px', fontFamily: 'var(--mono)', fontSize: '10px', fontWeight: 700}}>500 Error</span>
-              </div>
-              <div style={{display: 'flex', gap: '16px', fontSize: '12px', color: 'var(--ink3)'}}>
-                <span>event_id: <code style={{color: 'var(--accent)', fontFamily: 'var(--mono)'}}>evt_456def</code></span>
-                <span>type: <code style={{color: 'var(--accent)', fontFamily: 'var(--mono)'}}>push</code></span>
-                <span style={{marginLeft: 'auto'}}>45ms</span>
-              </div>
-            </div>
-
+      <main>
+        <section className="border-b border-stone-200 bg-[radial-gradient(circle_at_top_left,#fde6d6_0%,#f6deeb_40%,#e4eaf8_100%)]">
+          <div className="mx-auto grid w-full max-w-6xl gap-10 px-6 py-16 lg:grid-cols-2 lg:items-center lg:gap-14 lg:px-10">
             <div>
-              <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8}}>
-                <span style={{fontFamily: 'var(--mono)', fontSize: '12px', color: 'var(--ink)', fontWeight: 600}}>POST /custom/handler</span>
-                <span style={{background: '#dbeafe', color: '#0c4a6e', padding: '4px 10px', borderRadius: '4px', fontFamily: 'var(--mono)', fontSize: '10px', fontWeight: 700}}>202 Accepted</span>
+              <p className="mb-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-stone-600">
+                <span className="h-px w-6 bg-stone-500" />
+                CLI Tool
+              </p>
+              <h1 className="text-4xl font-medium leading-tight tracking-tight text-stone-950 md:text-5xl">
+                Test webhooks locally with a faster, cleaner workflow.
+              </h1>
+              <p className="mt-5 max-w-xl text-base leading-7 text-stone-700">
+                Tern gives you an instant public tunnel, a local dashboard, replay controls, and secure signature checks —
+                all without relying on long-lived third-party storage.
+              </p>
+
+              <div className="mt-8 flex flex-wrap items-center gap-3">
+                <a
+                  href="https://github.com/Hookflo/tern-dev"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-2 rounded-md bg-stone-900 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-stone-700"
+                >
+                  <Github size={16} />
+                  View GitHub
+                </a>
+                <a
+                  href="https://www.npmjs.com/package/@hookflo/tern-dev"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-2 rounded-md border border-stone-300 bg-white px-4 py-2.5 text-sm font-medium text-stone-800 transition hover:border-stone-500"
+                >
+                  <Download size={16} />
+                  View on npm
+                </a>
               </div>
-              <div style={{display: 'flex', gap: '16px', fontSize: '12px', color: 'var(--ink3)'}}>
-                <span>event_id: <code style={{color: 'var(--accent)', fontFamily: 'var(--mono)'}}>evt_789ghi</code></span>
-                <span>type: <code style={{color: 'var(--accent)', fontFamily: 'var(--mono)'}}>custom.test</code></span>
-                <span style={{marginLeft: 'auto'}}>1.8ms</span>
+            </div>
+
+            <div className="rounded-2xl border border-stone-200 bg-white/90 p-5 shadow-sm backdrop-blur">
+              <div className="mb-3 flex items-center justify-between text-xs font-medium text-stone-500">
+                <span className="inline-flex items-center gap-2">
+                  <Terminal size={14} />
+                  Quick start
+                </span>
+                <span>Copy command</span>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3 rounded-lg bg-stone-950 p-4 text-sm text-stone-100">
+                <code className="min-w-0 flex-1 break-all font-mono text-xs md:text-sm">{installCommand}</code>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  className="inline-flex items-center gap-1 rounded-md border border-cyan-800/60 bg-cyan-900/20 px-2.5 py-1.5 text-xs font-medium text-cyan-200 transition hover:bg-cyan-900/40"
+                  title="Copy install command"
+                >
+                  {copied ? <Check size={14} /> : <Copy size={14} />}
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+
+              <div className="mt-4 space-y-2 rounded-lg border border-stone-200 bg-stone-50 p-4 text-xs text-stone-700">
+                <p>
+                  <span className="font-semibold text-stone-900">Tunnel:</span> https://abc123.relay.tern.hookflo.com
+                </p>
+                <p>
+                  <span className="font-semibold text-stone-900">Dashboard:</span> http://localhost:2019
+                </p>
+                <p>
+                  <span className="font-semibold text-stone-900">Forwarding:</span> localhost:3000
+                </p>
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* CONFIG FILE */}
-      <section className="cli-dashboard-section">
-        <div className="cli-dashboard-inner">
-          <div className="cli-section-label">Configuration</div>
-          <h2 className="cli-h2">Persistent setup with config files</h2>
+        <section className="mx-auto w-full max-w-6xl px-6 py-16 lg:px-10">
+          <div className="mb-10 max-w-2xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-stone-500">Why teams use Tern</p>
+            <h2 className="mt-3 text-3xl font-medium tracking-tight text-stone-950">Built for local webhook development, not just tunneling.</h2>
+          </div>
 
-          <div className="cli-dashboard-grid" style={{marginBottom: 40}}>
-            <div className="cli-dashboard-content">
-              <h3>Manage settings with tern.config.json</h3>
-              <p>Store CLI flags in a configuration file and load them automatically.</p>
-              <ul className="cli-dashboard-list">
-                <li>Rate limiting and IP allowlisting</li>
-                <li>Block specific paths and HTTP methods</li>
-                <li>Custom relay server support</li>
-                <li>Session TTL and auto-kill timers</li>
-                <li>Audit logging to file</li>
-                <li>Full schema with IDE autocomplete</li>
+          <div className="grid gap-4 md:grid-cols-2">
+            {features.map(({ icon: Icon, title, description }) => (
+              <article key={title} className="rounded-xl border border-stone-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-stone-300">
+                <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-stone-100 text-stone-700">
+                  <Icon size={18} />
+                </div>
+                <h3 className="text-lg font-medium text-stone-900">{title}</h3>
+                <p className="mt-2 text-sm leading-6 text-stone-700">{description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="border-y border-stone-200 bg-white">
+          <div className="mx-auto grid w-full max-w-6xl gap-8 px-6 py-16 lg:grid-cols-2 lg:items-start lg:px-10">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-stone-500">How it works</p>
+              <h2 className="mt-3 text-3xl font-medium tracking-tight text-stone-950">From zero to receiving live events in under a minute.</h2>
+              <ul className="mt-6 space-y-3">
+                {quickSteps.map((step, index) => (
+                  <li key={step} className="flex items-start gap-3 text-sm leading-6 text-stone-700">
+                    <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-stone-900 text-xs font-medium text-white">
+                      {index + 1}
+                    </span>
+                    <span>{step}</span>
+                  </li>
+                ))}
               </ul>
             </div>
 
-            <div className="cli-code-block">
-              <div className="cli-code-header">
-                <div className="cli-code-dots">
-                  <div className="cli-code-dot" />
-                  <div className="cli-code-dot" />
-                  <div className="cli-code-dot" />
-                </div>
-                <span>tern.config.json</span>
+            <div className="overflow-hidden rounded-xl border border-stone-200 bg-stone-950 text-stone-100 shadow-sm">
+              <div className="flex items-center gap-2 border-b border-stone-800 px-4 py-3 text-xs text-stone-400">
+                <span className="h-2.5 w-2.5 rounded-full bg-red-400" />
+                <span className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+                <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
+                <span className="ml-2">terminal</span>
               </div>
-              <div className="cli-code-body">
-                {'{'}
-                <div style={{paddingLeft: '16px'}}>
-                  <div><span className="key">"port"</span>: <span className="num">3000</span>,</div>
-                  <div><span className="key">"rateLimit"</span>: <span className="num">100</span>,</div>
-                  <div><span className="key">"allowIp"</span>: [</div>
-                  <div style={{paddingLeft: '16px'}}><span className="str">"54.187.174.169"</span></div>
-                  <div>]</div>
-                </div>
-                {'}'}
+              <pre className="overflow-x-auto px-4 py-5 text-xs leading-6 text-stone-200 md:text-sm">
+{`$ npx @hookflo/tern-dev --port 3000
+
+✓ relay connected
+✓ dashboard ready at http://localhost:2019
+✓ forwarding POST /webhook to localhost:3000
+
+[12:33:04] POST /stripe/webhook   200   2.4ms
+[12:33:07] POST /github/events    500  45.1ms
+[12:33:09] POST /custom/handler   202   1.8ms`}
+              </pre>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto w-full max-w-6xl px-6 py-16 lg:px-10">
+          <div className="rounded-2xl border border-stone-200 bg-stone-900 px-6 py-10 text-stone-100 md:px-10">
+            <div className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+              <div className="max-w-2xl">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-stone-400">Ready to try it</p>
+                <h2 className="mt-3 text-3xl font-medium tracking-tight">Use Tern CLI in your next webhook integration.</h2>
+                <p className="mt-3 text-sm leading-6 text-stone-300">
+                  Works great for payment, auth, and event-driven testing loops where fast iteration matters.
+                </p>
+              </div>
+              <a
+                href="https://github.com/Hookflo/tern-dev"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 rounded-md bg-white px-4 py-2.5 text-sm font-medium text-stone-900 transition hover:bg-stone-200"
+              >
+                Start now
+                <ArrowRight size={16} />
+              </a>
+            </div>
+
+            <div className="mt-8 grid gap-3 sm:grid-cols-3">
+              <div className="rounded-lg border border-stone-700 bg-stone-800/70 p-3 text-sm">
+                <p className="text-stone-400">Median latency</p>
+                <p className="mt-1 text-lg font-semibold">&lt;100ms</p>
+              </div>
+              <div className="rounded-lg border border-stone-700 bg-stone-800/70 p-3 text-sm">
+                <p className="text-stone-400">Storage footprint</p>
+                <p className="mt-1 text-lg font-semibold">0 persisted events</p>
+              </div>
+              <div className="rounded-lg border border-stone-700 bg-stone-800/70 p-3 text-sm">
+                <p className="text-stone-400">Session control</p>
+                <p className="mt-1 inline-flex items-center gap-1 text-lg font-semibold">
+                  <Timer size={16} />
+                  Ctrl+C to reset
+                </p>
               </div>
             </div>
           </div>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="cli-cta">
-        <div className="cli-cta-inner">
-          <div style={{marginBottom: 60}}>
-            <h2 className="cli-cta-h">Ready to test webhooks locally?</h2>
-            <p className="cli-cta-desc">No account. No ngrok. No storage. Just one command and you're live.</p>
-          </div>
-          <div style={{display: 'flex', gap: 16, justifyContent: 'center', flexWrap: 'wrap'}}>
-            <a href="https://github.com/Hookflo/tern-dev" className="cli-btn-primary" target="_blank" rel="noreferrer" style={{fontSize: '14px', padding: '16px 40px'}}>
-              <Terminal size={18} />
-              Start on GitHub
-            </a>
-            <a href="https://www.npmjs.com/package/@hookflo/tern-dev" className="cli-btn-secondary" target="_blank" rel="noreferrer" style={{fontSize: '14px', padding: '16px 40px'}}>
-              <Download size={18} />
-              View on NPM
-            </a>
-          </div>
-        </div>
-      </section>
+        </section>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The CLI landing page was visually heavy and hard to scan, so the page was redesigned to surface value props and the quick-start command immediately.
- Improve onboarding by making the install command copyable and adding clear sections for features, workflow, terminal preview, and a stronger CTA.

### Description
- Rewrote `app/cli/page.tsx` to replace the large custom CSS hero with a two-column Tailwind-based hero that includes CTAs and a copyable install command (`installCommand`).
- Added structured data-driven feature cards (`features`) and a concise 3-step workflow (`quickSteps`) to make capabilities and flow easier to scan.
- Replaced earlier inline styles with a modern layout, updated icon set from `lucide-react`, and made the copy interaction asynchronous with a visible Copy/Copied state.
- Simplified the page into clear sections: hero, feature grid, how-it-works + terminal preview, and a bottom CTA with three supporting stats.

### Testing
- `npm run lint` was attempted but blocked by an interactive Next.js ESLint setup prompt in this environment, so lint could not complete non-interactively.
- `npm run build` was attempted and failed due to external font fetch errors from `app/layout.tsx` (Google Fonts network fetches), which is an environment/network limitation and not caused by the CLI page changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2af4f91d48324bb6f2667bde38d70)