### PR TITLE
Fix CLI page mobile responsiveness and add homepage CTA to CLI page

### DIFF
--- a/app/cli/page.tsx
+++ b/app/cli/page.tsx
@@ -151,7 +151,7 @@ const CSS = `
 
 /* ── BOXED BORDER (ankar.ai style) ── */
 .hero-box {
-  position: absolute; inset: clamp(16px,5vw,70px); z-index: 2; pointer-events: none;
+  position: absolute; inset: clamp(10px,2.8vw,48px); z-index: 2; pointer-events: none;
   border: 1px solid rgba(0,0,0,0.08);
   border-radius: 4px;
         background: linear-gradient(135deg, 
@@ -611,20 +611,24 @@ const CSS = `
     padding: 116px 12px 56px;
   }
   .hero-box {
-    inset: 8px;
+    inset: 5px;
     background-attachment: scroll;
   }
   .hero-sub {
     margin-bottom: 28px;
   }
   .hero-actions {
-    width: 100%;
+    width: auto;
     margin-bottom: 28px;
+    gap: 8px;
   }
   .btn-primary,
   .btn-secondary {
-    width: 100%;
+    width: auto;
+    min-width: 172px;
     justify-content: center;
+    font-size: 10px;
+    padding: 10px 16px;
   }
   .install-strip {
     display: grid;

--- a/app/cli/page.tsx
+++ b/app/cli/page.tsx
@@ -277,6 +277,8 @@ const CSS = `
   box-shadow: 0 12px 40px rgba(26,25,22,0.22), 0 2px 6px rgba(26,25,22,0.12);
   max-width: 580px; width: min(100%, 580px);
   border: 1px solid rgba(255,255,255,0.06);
+
+
 }
 .install-prefix {
   padding: 15px 18px;
@@ -905,7 +907,7 @@ export default function CLIPage() {
 
         {/* Boxed border */}
         <div className="hero-box">
-                   <svg id="noice" className=" inset-0 w-full h-full">
+          <svg id="noice" className=" inset-0 w-full h-full">
             <filter id="noise-filter">
               <feTurbulence
                 type="fractalNoise"
@@ -969,26 +971,26 @@ export default function CLIPage() {
             View on NPM
           </a>
         </div>
-
-        <div className="install-strip au au4">
-          <span className="install-prefix">$</span>
-          <span className="install-cmd">{CMD}</span>
-          <button
-            className={`install-copy${copied ? " copied" : ""}`}
-            onClick={handleCopy}
-          >
-            {copied ? (
-              <>
-                <Check size={12} /> Copied
-              </>
-            ) : (
-              <>
-                <Copy size={12} /> Copy
-              </>
-            )}
-          </button>
+        <div className="px-30">
+          <div className="install-strip au au4">
+            <span className="install-prefix">$</span>
+            <span className="install-cmd">{CMD}</span>
+            <button
+              className={`install-copy${copied ? " copied" : ""}`}
+              onClick={handleCopy}
+            >
+              {copied ? (
+                <>
+                  <Check size={12} /> Copied
+                </>
+              ) : (
+                <>
+                  <Copy size={12} /> Copy
+                </>
+              )}
+            </button>
+          </div>
         </div>
-
         <div className="hero-hint text-black">
           three steps to live webhook debugging
         </div>
@@ -1029,24 +1031,22 @@ export default function CLIPage() {
       {/* ── TERMINAL / QUICKSTART ── */}
       <section className="terminal-section">
         <div className="terminal-inner">
-       
-
           <div className="terminal-grid">
             <div>
-                 <div className="section-label">
-            <span className="section-label-dot" />
-            Getting Started
-          </div>
-          <h2 className="section-h2 ">
-            Three steps to <em>live</em>
-          </h2>
+              <div className="section-label">
+                <span className="section-label-dot" />
+                Getting Started
+              </div>
+              <h2 className="section-h2 ">
+                Three steps to <em>live</em>
+              </h2>
               <p
                 style={{
                   fontSize: 14.5,
                   color: "var(--ink3)",
                   lineHeight: 1.7,
                   marginBottom: 8,
-                  marginTop:30
+                  marginTop: 30,
                 }}
               >
                 No installs, no configuration, no account. Run{" "}
@@ -1095,7 +1095,6 @@ export default function CLIPage() {
                 </span>
               </div>
               <div className="term-body">
-                
                 <div className="cli-code-body">{`# 1. Start the tunnel
 $ npx @hookflo/tern-dev --port 3000
 

--- a/app/cli/page.tsx
+++ b/app/cli/page.tsx
@@ -52,6 +52,7 @@ const CSS = `
   background: var(--bg);
   color: var(--ink);
   -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
 }
 
 /* ── NOISE LAYER (global) ── */
@@ -74,7 +75,7 @@ const CSS = `
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 150px clamp(24px,5vw,80px) 90px;
+  padding: 150px clamp(16px,5vw,80px) 90px;
   text-align: center;
   overflow: hidden;
   isolation: isolate;
@@ -150,7 +151,7 @@ const CSS = `
 
 /* ── BOXED BORDER (ankar.ai style) ── */
 .hero-box {
-  position: absolute; inset: 70px; z-index: 2; pointer-events: none;
+  position: absolute; inset: clamp(16px,5vw,70px); z-index: 2; pointer-events: none;
   border: 1px solid rgba(0,0,0,0.08);
   border-radius: 4px;
         background: linear-gradient(135deg, 
@@ -274,7 +275,7 @@ const CSS = `
   display: inline-flex; align-items: center;
   background: var(--ink); border-radius: 10px; overflow: hidden;
   box-shadow: 0 12px 40px rgba(26,25,22,0.22), 0 2px 6px rgba(26,25,22,0.12);
-  max-width: 580px; width: 100%;
+  max-width: 580px; width: min(100%, 580px);
   border: 1px solid rgba(255,255,255,0.06);
 }
 .install-prefix {
@@ -284,7 +285,7 @@ const CSS = `
   flex-shrink: 0;
 }
 .install-cmd {
-  flex: 1; padding: 15px 16px;
+  flex: 1; min-width: 0; padding: 15px 16px;
   font-family: var(--mono); font-size: 12.5px; font-weight: 400;
   color: rgba(240,238,232,0.85); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   background: transparent; border: none; outline: none;
@@ -571,11 +572,22 @@ const CSS = `
   border-top: 1px solid var(--border);
 }
 .flags-inner { max-width: 1360px; margin: 0 auto; }
+.flags-table-wrap {
+  width: 100%;
+  margin-top: 44px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+}
 
 .flags-table {
-  width: 100%; border-collapse: collapse;
-  border: 1px solid var(--border); border-radius: 12px; overflow: hidden;
-  margin-top: 44px; background: var(--surface);
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+  border: none;
+  background: var(--surface);
 }
 .flags-table th {
   background: var(--bg2); font-family: var(--mono); font-size: 9px;
@@ -593,6 +605,37 @@ const CSS = `
 .flag-type { font-family: var(--mono); font-size: 11px; color: var(--teal); }
 .flag-default { font-family: var(--mono); font-size: 11px; color: var(--ink4); }
 .flag-desc { color: var(--ink2); font-size: 13px; line-height: 1.55; }
+@media(max-width: 768px) {
+  .hero {
+    min-height: auto;
+    padding: 116px 12px 56px;
+  }
+  .hero-box {
+    inset: 8px;
+    background-attachment: scroll;
+  }
+  .hero-sub {
+    margin-bottom: 28px;
+  }
+  .hero-actions {
+    width: 100%;
+    margin-bottom: 28px;
+  }
+  .btn-primary,
+  .btn-secondary {
+    width: 100%;
+    justify-content: center;
+  }
+  .install-strip {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+  }
+  .install-prefix,
+  .install-cmd,
+  .install-copy {
+    padding: 12px;
+  }
+}
 
 /* ═══════════════════════════ CONFIG SECTION ═══════════════════════════ */
 .config-section {
@@ -1225,34 +1268,36 @@ $ npx @hookflo/tern-dev --port 3000
             persistent configuration.
           </p>
 
-          <table className="flags-table">
-            <thead>
-              <tr>
-                <th>Flag</th>
-                <th>Type</th>
-                <th>Default</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              {flags.map((f, i) => (
-                <tr key={i}>
-                  <td>
-                    <span className="flag-name">{f.name}</span>
-                  </td>
-                  <td>
-                    <span className="flag-type">{f.type}</span>
-                  </td>
-                  <td>
-                    <span className="flag-default">{f.def}</span>
-                  </td>
-                  <td>
-                    <span className="flag-desc">{f.desc}</span>
-                  </td>
+          <div className="flags-table-wrap">
+            <table className="flags-table">
+              <thead>
+                <tr>
+                  <th>Flag</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {flags.map((f, i) => (
+                  <tr key={i}>
+                    <td>
+                      <span className="flag-name">{f.name}</span>
+                    </td>
+                    <td>
+                      <span className="flag-type">{f.type}</span>
+                    </td>
+                    <td>
+                      <span className="flag-default">{f.def}</span>
+                    </td>
+                    <td>
+                      <span className="flag-desc">{f.desc}</span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -883,8 +883,13 @@ export default function HomePage() {
               no fragile hand-rolled crypto.
             </p>
             <div className="t-actions fade-up-4">
-              <a href="#how" className="t-btn-primary">
-                Get started
+              <a
+                href="https://github.com/Hookflo/tern"
+                target="_blank"
+                rel="noreferrer"
+                className="t-btn-primary"
+              >
+                Star on GitHub
                 <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
                   <path
                     d="M3 7h8M8 4l3 3-3 3"
@@ -896,7 +901,7 @@ export default function HomePage() {
                 </svg>
               </a>
               <Link href="/cli" className="t-btn-secondary">
-                Open Tern CLI
+                Tern CLI
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
                   <path
                     d="M2 10L10 2M10 2H4M10 2v6"
@@ -906,22 +911,6 @@ export default function HomePage() {
                   />
                 </svg>
               </Link>
-              <a
-                href="https://github.com/Hookflo/tern"
-                target="_blank"
-                rel="noreferrer"
-                className="t-btn-secondary"
-              >
-                Star on GitHub
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path
-                    d="M2 10L10 2M10 2H4M10 2v6"
-                    stroke="currentColor"
-                    strokeWidth="1.3"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </a>
             </div>
             <div className="t-hero-badges fade-up-5">
               <div className="t-oss-badge">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -895,6 +895,17 @@ export default function HomePage() {
                   />
                 </svg>
               </a>
+              <Link href="/cli" className="t-btn-secondary">
+                Open Tern CLI
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path
+                    d="M2 10L10 2M10 2H4M10 2v6"
+                    stroke="currentColor"
+                    strokeWidth="1.3"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </Link>
               <a
                 href="https://github.com/Hookflo/tern"
                 target="_blank"


### PR DESCRIPTION
### Motivation
- The CLI page exhibited horizontal scrolling and broken hero layout on small screens, making the UI unusable on mobile devices. 
- The home landing lacked a quick action to open the Tern CLI page, so a CTA linking to `/cli` was requested.

### Description
- Prevent global horizontal overflow by adding `overflow-x: hidden` to the page root and tighten hero horizontal padding to reduce edge overflow (`app/cli/page.tsx`).
- Make the hero boxed border responsive by using `inset: clamp(16px,5vw,70px)` and add mobile-specific adjustments so hero height, spacing and actions stack cleanly (`app/cli/page.tsx`).
- Improve install strip and button layout on small screens by bounding widths (`width: min(100%, 580px)`), adding `min-width: 0` to command cell, and switching the install strip to a mobile grid at narrow breakpoints (`app/cli/page.tsx`).
- Make the CLI flags table responsive by wrapping it in a horizontally-scrollable container `.flags-table-wrap` and keeping the table at a minimum width so it can be scrolled independently (`app/cli/page.tsx`).
- Add a new homepage action button that links to the CLI page (`/cli`) to provide a direct path from the landing page (`app/page.tsx`).

### Testing
- Ran `npm run lint`, which was blocked by Next.js prompting for interactive ESLint setup in this environment. 
- Ran `npm run build`, which failed due to inability to fetch Google Fonts during the Next.js build in this environment, so a full production build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cc0d98a08324bb79ed3b3490dad1)